### PR TITLE
Fix: RootLayout에서 발생하는 className did not match 오류 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko" className="dark">
+    <html lang="ko" className="dark" suppressHydrationWarning>
       <body>
         <UIProvider>
           <Header />

--- a/src/component/themeSwitcher/ThemeSwitcher.tsx
+++ b/src/component/themeSwitcher/ThemeSwitcher.tsx
@@ -11,8 +11,7 @@ const ThemeSwitcher = () => {
   const { theme, setTheme } = useTheme();
 
   const handleSwitchTheme = React.useCallback(() => {
-    if (theme === 'light') setTheme('dark');
-    if (theme === 'dark') setTheme('light');
+    setTheme(theme === 'light' ? 'dark' : 'light');
   }, [theme]);
 
   React.useEffect(() => {


### PR DESCRIPTION
- 오류: app-index.js:33 Warning: Prop `className` did not match. Server: "light" Client: "dark" at htm at RootLayout (Server)
- RootLayour의 html태그에 supperssHydrationWarning 속성 추가하여 해결
- handleSwitchTheme 함수 로직 간소화