### PR TITLE
Test: socket mocking

### DIFF
--- a/__test__/components/game/playZone/wordList/WordList.test.tsx
+++ b/__test__/components/game/playZone/wordList/WordList.test.tsx
@@ -1,11 +1,21 @@
 import { render, screen } from '@testing-library/react';
+import { afterAll } from 'vitest';
 
 import WordList from '@/components/game/playZone/wordList/WordList';
+import { createMockSocket, type MockSocket } from '__test__/utils';
 
 const mockWords = ['대나무', '무다리', '리어카'];
 
 describe('WordList', () => {
-  beforeEach(() => {
+  const mockSocket: MockSocket = {
+    io: null,
+    serverSocket: null,
+    clientSocket: null,
+  };
+
+  beforeAll(async () => {
+    await createMockSocket(mockSocket);
+
     vi.mock('@/store/wordStore', () => ({
       useWordState: vi.fn(() => mockWords),
       useWordActions: vi.fn(() => ({
@@ -16,10 +26,9 @@ describe('WordList', () => {
     }));
   });
 
-  afterEach(() => {
+  afterAll(() => {
     vi.clearAllMocks();
   });
-
   it.each(mockWords)('should render enterd word', (word) => {
     render(<WordList />);
 

--- a/__test__/components/game/playZone/wordList/WordList.test.tsx
+++ b/__test__/components/game/playZone/wordList/WordList.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { afterAll } from 'vitest';
 
 import WordList from '@/components/game/playZone/wordList/WordList';
-import { createMockSocket, type MockSocket } from '__test__/utils';
+import { createMockSocket, deleteMockSocket, type MockSocket } from '__test__/utils';
 
 const mockWords = ['대나무', '무다리', '리어카'];
 
@@ -28,7 +28,10 @@ describe('WordList', () => {
 
   afterAll(() => {
     vi.clearAllMocks();
+
+    deleteMockSocket(mockSocket);
   });
+
   it.each(mockWords)('should render enterd word', (word) => {
     render(<WordList />);
 

--- a/__test__/components/game/players/Players.test.tsx
+++ b/__test__/components/game/players/Players.test.tsx
@@ -1,17 +1,11 @@
 import { render, screen } from '@testing-library/react';
 
 import Players from '@/components/game/players/Players';
+import { mockPlayers, mockRoomChief } from '__test__/mocks/players';
 import { createMockSocket, deleteMockSocket } from '__test__/utils';
 
 import type { PlayerType } from '@/store/playerStore';
 import type { MockSocket } from '__test__/utils';
-
-// socket io 모킹 후 faker 사용 예정
-const mockPlayers: PlayerType[] = [
-  { socketId: 'a1', userId: 'a1', nickname: 'a1', isRoomChief: true },
-  { socketId: 'a2', userId: 'a2', nickname: 'a2', isRoomChief: false },
-  { socketId: 'a3', userId: 'a3', nickname: 'a3', isRoomChief: false },
-];
 
 describe('Players', () => {
   const mockSocket: MockSocket = {
@@ -42,10 +36,18 @@ describe('Players', () => {
     deleteMockSocket(mockSocket);
   });
 
-  it.each(mockPlayers)('should render players nickname', ({ userId, nickname }) => {
-    const playerChip = screen.getByTestId(userId);
+  it('should render room chief', () => {
+    return new Promise<void>((resolve) => {
+      mockSocket.clientSocket?.on('createRoomSuccess', ({ userId, nickname }: PlayerType) => {
+        const playerChip = screen.getByTestId(userId);
 
-    expect(playerChip).toBeInTheDocument();
-    expect(playerChip).toHaveTextContent(nickname);
+        expect(playerChip).toBeInTheDocument();
+        expect(playerChip).toHaveTextContent(nickname);
+
+        resolve();
+      });
+
+      mockSocket.serverSocket?.emit('createRoomSuccess', mockRoomChief);
+    });
   });
 });

--- a/__test__/components/game/players/Players.test.tsx
+++ b/__test__/components/game/players/Players.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
 import Players from '@/components/game/players/Players';
-import { createMockSocket } from '__test__/utils';
+import { createMockSocket, deleteMockSocket } from '__test__/utils';
 
 import type { PlayerType } from '@/store/playerStore';
 import type { MockSocket } from '__test__/utils';
@@ -34,6 +34,12 @@ describe('Players', () => {
     }));
 
     render(<Players />);
+  });
+
+  afterAll(() => {
+    vi.clearAllMocks();
+
+    deleteMockSocket(mockSocket);
   });
 
   it.each(mockPlayers)('should render players nickname', ({ userId, nickname }) => {

--- a/__test__/components/game/players/Players.test.tsx
+++ b/__test__/components/game/players/Players.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
 
 import Players from '@/components/game/players/Players';
+import { createMockSocket } from '__test__/utils';
 
 import type { PlayerType } from '@/store/playerStore';
+import type { MockSocket } from '__test__/utils';
 
 // socket io 모킹 후 faker 사용 예정
 const mockPlayers: PlayerType[] = [
@@ -12,7 +14,15 @@ const mockPlayers: PlayerType[] = [
 ];
 
 describe('Players', () => {
-  beforeEach(() => {
+  const mockSocket: MockSocket = {
+    io: null,
+    serverSocket: null,
+    clientSocket: null,
+  };
+
+  beforeEach(async () => {
+    await createMockSocket(mockSocket);
+
     vi.mock('@/store/playerStore', () => ({
       usePlayerState: vi.fn(() => mockPlayers),
       usePlayerActions: vi.fn(() => ({

--- a/__test__/mocks/players.ts
+++ b/__test__/mocks/players.ts
@@ -1,0 +1,22 @@
+import { faker } from '@faker-js/faker';
+
+import type { PlayerType } from '@/store/playerStore';
+
+export const mockRoomChief: PlayerType = {
+  socketId: faker.string.nanoid(),
+  userId: faker.string.nanoid(),
+  nickname: faker.person.fullName(),
+  isRoomChief: true,
+};
+
+export const mockPlayers: PlayerType[] = [
+  mockRoomChief,
+  ...Array.from(Array(6), () => {
+    return {
+      socketId: faker.string.nanoid(),
+      userId: faker.string.nanoid(),
+      nickname: faker.person.fullName(),
+      isRoomChief: false,
+    };
+  }),
+];

--- a/__test__/utils.tsx
+++ b/__test__/utils.tsx
@@ -1,0 +1,41 @@
+import { createServer } from 'node:http';
+import { type AddressInfo } from 'node:net';
+
+import { Server, type Socket as ServerSocket } from 'socket.io';
+import { type Socket as ClientSocket, io as ioc } from 'socket.io-client';
+
+export const waitFor = (socket: ServerSocket | ClientSocket, event: string) => {
+  return new Promise((resolve) => {
+    socket.once(event, resolve);
+  });
+};
+
+export interface MockSocket {
+  io: Server | null;
+  serverSocket: ServerSocket | null;
+  clientSocket: ClientSocket | null;
+}
+
+export const createMockSocket = async (mockSocket: MockSocket) => {
+  await new Promise<void>((resolve) => {
+    const httpServer = createServer();
+    mockSocket.io = new Server(httpServer);
+
+    httpServer.listen(() => {
+      const port = (httpServer.address() as AddressInfo).port;
+      mockSocket.clientSocket = ioc(`http://localhost:${port}`);
+
+      mockSocket.io?.on('connection', (socket) => {
+        mockSocket.serverSocket = socket;
+      });
+      mockSocket.clientSocket.on('connect', resolve);
+    });
+  });
+};
+
+export const deleteMockSocket = (mockSocket: MockSocket) => {
+  if (mockSocket.clientSocket === null || mockSocket.io === null) return;
+
+  mockSocket.io.close();
+  mockSocket.clientSocket.disconnect();
+};

--- a/src/components/loby/createRoom/CreateRoom.tsx
+++ b/src/components/loby/createRoom/CreateRoom.tsx
@@ -9,10 +9,11 @@ import { createRoomId } from '@/utils/createRoomId';
 
 import type { CreateOrJoinSocketRoomArgs } from '@/hooks/useSocket';
 import type { UserType } from '@/types/auth.type';
+import type { DebouncedFuncLeading } from 'lodash';
 
 interface Props {
   user: UserType | null;
-  createSocketRoom: (args: CreateOrJoinSocketRoomArgs) => Promise<boolean>;
+  createSocketRoom: DebouncedFuncLeading<(args: CreateOrJoinSocketRoomArgs) => Promise<boolean>>;
 }
 
 const CreateRoom = ({ user, createSocketRoom }: Props) => {

--- a/src/components/loby/enterRoom/EnterRoom.tsx
+++ b/src/components/loby/enterRoom/EnterRoom.tsx
@@ -13,13 +13,14 @@ import { EnterRoomSchema } from '@/schema/enterRoomSchema';
 
 import type { CreateOrJoinSocketRoomArgs } from '@/hooks/useSocket';
 import type { UserType } from '@/types/auth.type';
+import type { DebouncedFuncLeading } from 'lodash';
 import type { z } from 'zod';
 
 type EnterRoomInput = z.infer<typeof EnterRoomSchema>;
 
 interface Props {
   user: UserType | null;
-  joinSocketRoom: (args: CreateOrJoinSocketRoomArgs) => Promise<boolean>;
+  joinSocketRoom: DebouncedFuncLeading<(args: CreateOrJoinSocketRoomArgs) => Promise<boolean>>;
 }
 
 const EnterRoom = ({ user, joinSocketRoom }: Props) => {


### PR DESCRIPTION
- __test__/utils.tsx에 createMockSocket, deleteMockSocket 함수 추가
- WordList.test.tsx, Player.test.tsx에 createMockSocket, deleteMockSocket 함수 적용
- __test__/mocks에 players.ts를 추가하여 mockRoomChief, mockPlayers 추가
- Players.test.tsx의 기존 should render players 테스트 삭제 후 should render room chief 테스트 추가하여 소켓이 모킹이 잘 되었음을 확인
- CreateRoom.tsx, EnterRoom.tsx 컴포넌트의 인자 타입 오류 수정