### PR TITLE
refactor: convertDueum 함수 리팩토링

### DIFF
--- a/src/constants/dueum.ts
+++ b/src/constants/dueum.ts
@@ -1,3 +1,3 @@
-export const DUEUM_MOEUM_RIEUL_TO_NIEUN = ['ㅏ', 'ㅐ', 'ㅗ', 'ㅚ', 'ㅜ', 'ㅡ'];
+export const DUEUM_MOEUM_RIEUL_TO_NIEUN = ['ㅏ', 'ㅐ', 'ㅗ', 'ㅗㅣ', 'ㅜ', 'ㅡ'];
 export const DUEUM_MOEUM_RIEUL_TO_IEUNG = ['ㅑ', 'ㅕ', 'ㅛ', 'ㅠ', 'ㅣ', 'ㅖ'];
 export const DUEUM_MOEUM_NIEUN_TO_IEUNG = ['ㅕ', 'ㅛ', 'ㅠ', 'ㅣ'];

--- a/src/utils/checkWordValid.ts
+++ b/src/utils/checkWordValid.ts
@@ -7,41 +7,33 @@ import {
 } from '@/constants/dueum';
 import { checkDictionary } from '@/lib/word';
 
+type ConversionRule = { moeums: string[]; targetChoseong: 'ㅇ' | 'ㄴ' };
+const conversionRules: Record<string, Array<ConversionRule>> = {
+  ㄴ: [{ moeums: DUEUM_MOEUM_NIEUN_TO_IEUNG, targetChoseong: 'ㅇ' }],
+  ㄹ: [
+    { moeums: DUEUM_MOEUM_RIEUL_TO_NIEUN, targetChoseong: 'ㄴ' },
+    { moeums: DUEUM_MOEUM_RIEUL_TO_IEUNG, targetChoseong: 'ㅇ' },
+  ],
+};
+
 /**
  * 글자가 두음 법칙이 적용되는 글자면 두음 법칙을 적용한 글자를 반환.
  * 아닐 경우 글자 그대로 반환
  */
 const convertDueum = (char: string) => {
-  const disassembleChar = disassembleCompleteCharacter(char);
-  const isNieun = disassembleChar?.choseong === 'ㄴ';
-  const isRieul = disassembleChar?.choseong === 'ㄹ';
+  const disassembledChar = disassembleCompleteCharacter(char);
+  if (!disassembledChar) return char;
 
-  if (isNieun) {
-    const isDueumMoeum = DUEUM_MOEUM_NIEUN_TO_IEUNG.includes(disassembleChar.jungseong);
-    if (isDueumMoeum) {
-      disassembleChar.choseong = 'ㅇ';
-      const finalCharacter = assemble(Object.values(disassembleChar));
-      return finalCharacter;
+  const { choseong, jungseong } = disassembledChar;
+
+  const rules = conversionRules[choseong];
+  if (!rules) return char;
+
+  for (const rule of rules) {
+    if (rule.moeums.includes(jungseong)) {
+      disassembledChar.choseong = rule.targetChoseong;
+      return assemble(Object.values(disassembledChar));
     }
-
-    return char;
-  }
-
-  if (isRieul) {
-    const isDueumMoeumToNieun = DUEUM_MOEUM_RIEUL_TO_NIEUN.includes(disassembleChar.jungseong);
-    if (isDueumMoeumToNieun) {
-      disassembleChar.choseong = 'ㄴ';
-      const finalCharacter = assemble(Object.values(disassembleChar));
-      return finalCharacter;
-    }
-    const isDueumMoeumToIeung = DUEUM_MOEUM_RIEUL_TO_IEUNG.includes(disassembleChar.jungseong);
-    if (isDueumMoeumToIeung) {
-      disassembleChar.choseong = 'ㅇ';
-      const finalCharacter = assemble(Object.values(disassembleChar));
-      return finalCharacter;
-    }
-
-    return char;
   }
 
   return char;


### PR DESCRIPTION
- 모음이 변환되는 규칙을 conversionRules 객체로 만들어서 사용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 두음 법칙 변환 로직이 데이터 기반 방식으로 개선되어 코드가 간결해졌습니다.

- **Style**
  - 두음 법칙 관련 상수 배열이 일부 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->